### PR TITLE
README: fix rust docstring

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,7 +462,7 @@ def add(a: int, b: int) -> int:
 **Rust**
 
 ```rust
-// Adds a to b
+/// Adds a to b
 fn add(a: i32, b: i32) -> i32 {
   a + b
 }


### PR DESCRIPTION
In the function example the python docstring is turned into a comment, by using `///` we can make it also a docstring in rust