### PR TITLE
fixes function argument and return types

### DIFF
--- a/README.md
+++ b/README.md
@@ -938,7 +938,7 @@ except ValueError:
 **Rust**
 
 ```rust
-fn div(a: f64, b: f64) -> Result<f64, &'static str> {
+fn div(a: i32, b: i32) -> Result<i32, &'static str> {
     if b == 0 {
         Err("b can't be 0")
     } else {


### PR DESCRIPTION
There is a mismatch between function arguments and the data provided...
```
   Compiling playground v0.0.1 (/playground)
error[E0308]: mismatched types
 --> src/main.rs:2:13
  |
2 |     if b == 0 {
  |             ^
  |             |
  |             expected `f64`, found integer
  |             help: use a float literal: `0.0`

error[E0308]: mismatched types
  --> src/main.rs:10:15
   |
10 |     match div(1, 0) {
   |               ^
   |               |
   |               expected `f64`, found integer
   |               help: use a float literal: `1.0`

error[E0308]: mismatched types
  --> src/main.rs:10:18
   |
10 |     match div(1, 0) {
   |                  ^
   |                  |
   |                  expected `f64`, found integer
   |                  help: use a float literal: `0.0`
```
link to [play](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=7f3c2e9940ef4def031156d0aae902fc)

Changed the argument types to i32 to make it work with the inputs provided. Thanks! 